### PR TITLE
[ci skip] adding user @username

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @CJ-Wright
+* @username

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,4 +62,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - username
     - CJ-Wright


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @username as instructed in #74.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #74